### PR TITLE
Refactor admin builder v2, mask sensitive info, improve tests

### DIFF
--- a/rest/admin-v2/api/src/main/java/org/keycloak/events/admin/v2/AdminEventV2Builder.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/events/admin/v2/AdminEventV2Builder.java
@@ -16,18 +16,15 @@
  */
 package org.keycloak.events.admin.v2;
 
-import java.io.IOException;
+
+import jakarta.ws.rs.core.UriInfo;
 
 import org.keycloak.common.ClientConnection;
-import org.keycloak.events.admin.AdminEvent;
-import org.keycloak.events.admin.ResourceType;
-import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.StripSecretsUtilsV2;
 import org.keycloak.services.resources.admin.AdminAuth;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
-import org.keycloak.util.JsonSerialization;
 
 /**
  * Builder for Admin API v2 events.
@@ -37,7 +34,6 @@ import org.keycloak.util.JsonSerialization;
  * - Representation is serialized without stripping secrets (v2 representations handle this differently).
  */
 public class AdminEventV2Builder extends AdminEventBuilder {
-
     private static final String API_VERSION_DETAIL_KEY = "apiVersion";
     private static final String API_VERSION_V2 = "v2";
 
@@ -47,64 +43,15 @@ public class AdminEventV2Builder extends AdminEventBuilder {
         detail(API_VERSION_DETAIL_KEY, API_VERSION_V2);
     }
 
-    private AdminEventV2Builder(RealmModel realm, AdminAuth auth, KeycloakSession session, String ipAddress, AdminEvent adminEvent) {
-        super(realm, auth, session, ipAddress, adminEvent);
-        // The v2 detail is already in the adminEvent copy
-    }
-
-    /**
-     * Create a new instance of the {@link AdminEventV2Builder} that is bound to a new session.
-     * Use this when starting, for example, a nested transaction.
-     * @param session new session where the {@link AdminEventV2Builder} should be bound to.
-     * @return a new instance of {@link AdminEventV2Builder}
-     */
     @Override
-    public AdminEventV2Builder clone(KeycloakSession session) {
-        RealmModel newEventRealm = session.realms().getRealm(realm.getId());
-        RealmModel newAuthRealm = session.realms().getRealm(this.auth.getRealm().getId());
-        UserModel newAuthUser = session.users().getUserById(newAuthRealm, this.auth.getUser().getId());
-        ClientModel newAuthClient = session.clients().getClientById(newAuthRealm, this.auth.getClient().getId());
-
-        return new AdminEventV2Builder(
-                newEventRealm,
-                new AdminAuth(newAuthRealm, this.auth.getToken(), newAuthUser, newAuthClient),
-                session,
-                ipAddress,
-                adminEvent
-        );
+    protected String getResourcePath(UriInfo uriInfo) {
+        String path = uriInfo.getPath();
+        String realmRelative = "/admin/api/%s/".formatted(realm.getName());
+        return path.substring(path.indexOf(realmRelative) + realmRelative.length());
     }
 
     @Override
-    public AdminEventV2Builder resource(ResourceType resourceType) {
-        super.resource(resourceType);
-        return this;
-    }
-
-    @Override
-    public AdminEventV2Builder resource(String resourceType) {
-        super.resource(resourceType);
-        return this;
-    }
-
-    /**
-     * Sets the v2 representation to be included in the event.
-     * The representation is serialized to JSON without stripping secrets
-     * (v2 representations handle sensitive data differently).
-     * 
-     * @param value the v2 representation object (e.g., BaseClientRepresentation)
-     * @return this builder
-     */
-    @Override
-    public AdminEventV2Builder representation(Object value) {
-        if (value == null || value.equals("")) {
-            return this;
-        }
-
-        try {
-            adminEvent.setRepresentation(JsonSerialization.writeValueAsString(value));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return this;
+    protected void stripSecretsFromRepresentation(Object value) {
+        StripSecretsUtilsV2.stripSecrets(session, value);
     }
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/models/utils/StripSecretsUtilsV2.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/models/utils/StripSecretsUtilsV2.java
@@ -1,0 +1,44 @@
+package org.keycloak.models.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
+import org.keycloak.representations.admin.v2.SAMLClientRepresentation;
+import org.keycloak.utils.StringUtil;
+
+/**
+ * Strip secrets from representations
+ */
+public class StripSecretsUtilsV2 extends StripSecretsUtils {
+    private static final Map<Class<?>, BiConsumer<KeycloakSession, Object>> REPRESENTATION_FORMATTER = new HashMap<>();
+
+    static {
+        REPRESENTATION_FORMATTER.put(OIDCClientRepresentation.class, (session, o) -> StripSecretsUtilsV2.stripOidcClient((OIDCClientRepresentation) o));
+        REPRESENTATION_FORMATTER.put(SAMLClientRepresentation.class, (session, o) -> StripSecretsUtilsV2.stripSamlClient((SAMLClientRepresentation) o));
+    }
+
+    public static <T> T stripSecrets(KeycloakSession session, T representation) {
+        return stripSecrets(session, representation, REPRESENTATION_FORMATTER);
+    }
+
+    protected static OIDCClientRepresentation stripOidcClient(OIDCClientRepresentation rep) {
+        Optional.ofNullable(rep.getAuth())
+                .map(OIDCClientRepresentation.Auth::getSecret)
+                .filter(StringUtil::isNotBlank)
+                .ifPresent(secret -> rep.getAuth().setSecret(maskNonVaultValue(secret)));
+        return rep;
+    }
+
+    protected static SAMLClientRepresentation stripSamlClient(SAMLClientRepresentation rep) {
+        Optional.ofNullable(rep.getSigningCertificate())
+                .filter(StringUtil::isNotBlank)
+                .ifPresent(cert -> rep.setSigningCertificate(maskNonVaultValue(cert)));
+
+        return rep;
+    }
+
+}

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
@@ -64,7 +64,11 @@ public class StripSecretsUtils {
     }
 
     public static <T> T stripSecrets(KeycloakSession session, T representation) {
-        BiConsumer<KeycloakSession, Object> formatter = REPRESENTATION_FORMATTER.get(representation.getClass());
+        return stripSecrets(session, representation, REPRESENTATION_FORMATTER);
+    }
+
+    protected static <T> T stripSecrets(KeycloakSession session, T representation, Map<Class<?>, BiConsumer<KeycloakSession, Object>> formatters) {
+        BiConsumer<KeycloakSession, Object> formatter = formatters.get(representation.getClass());
 
         if (formatter == null) {
             return representation;
@@ -75,7 +79,7 @@ public class StripSecretsUtils {
         return representation;
     }
 
-    private static String maskNonVaultValue(String value) {
+    protected static String maskNonVaultValue(String value) {
         return value == null
           ? null
           : (VAULT_VALUE.matcher(value).matches()

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
@@ -241,7 +241,7 @@ public class AdminEventBuilder {
         return this;
     }
 
-    private String getResourcePath(UriInfo uriInfo) {
+    protected String getResourcePath(UriInfo uriInfo) {
         String path = uriInfo.getPath();
 
         StringBuilder sb = new StringBuilder();
@@ -258,7 +258,7 @@ public class AdminEventBuilder {
             return this;
         }
 
-        stripSecrets(session, value);
+        stripSecretsFromRepresentation(value);
 
         try {
             adminEvent.setRepresentation(JsonSerialization.writeValueAsString(value));
@@ -266,6 +266,10 @@ public class AdminEventBuilder {
             throw new RuntimeException(e);
         }
         return this;
+    }
+
+    protected void stripSecretsFromRepresentation(Object value){
+        stripSecrets(session, value);
     }
 
     public AdminEventBuilder detail(String key, String value) {


### PR DESCRIPTION
- Refactors the AdminEventBuilder 
- Provides the `getResourcePath()` to have proper resource path for V2 + tests
- Mask sensitive info from the representation inside of the event (secret for OIDC + signCert for SAML) -> strip secrets + tests
- Improved test manageability + remove duplications

@edewit Here are some changes that I'd like to have included in your PR. Does it work for you? 
